### PR TITLE
Update to Scala 2.12.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: scala
 scala:
-  - 2.12.110
+  - 2.12.10
 jdk:
   - openjdk8
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: scala
 scala:
-  - 2.11.11
+  - 2.12.110
 jdk:
-  - oraclejdk8
+  - openjdk8
 script:
   - sbt test
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,21 +1,25 @@
-val scalaExercisesV = "0.4.0-SNAPSHOT"
+import ProjectPlugin.autoImport._
+
+val scalaExercisesV = "0.5.0-SNAPSHOT"
 
 def dep(artifactId: String) = "org.scala-exercises" %% artifactId % scalaExercisesV
 
 lazy val monocle = (project in file("."))
-.enablePlugins(ExerciseCompilerPlugin)
-.settings(
-     name         := "exercises-monocle",
-     libraryDependencies ++= Seq(
-        dep("exercise-compiler"),
-        dep("definitions"),
-        %%("monocle-core" ),
-        %%("monocle-macro" ),
-        %%("scalatest"),
-        %%("scalacheck"),
-        %%("scheckShapeless")
-    )
-)
+  .enablePlugins(ExerciseCompilerPlugin)
+  .settings(
+    name := "exercises-monocle",
+    libraryDependencies ++= Seq(
+      dep("exercise-compiler"),
+      dep("definitions"),
+      %%("monocle-core", V.monocle),
+      %%("monocle-macro", V.monocle),
+      %%("scalatest", V.scalatest),
+      %%("scalacheck", V.scalacheck),
+      "org.typelevel"              %% "alleycats-core"            % V.cats,
+      "com.github.alexarchambault" %% "scalacheck-shapeless_1.14" % V.scalacheckShapeless
+    ),
+    addCompilerPlugin("org.scalamacros" %% "paradise" % "2.1.1" cross CrossVersion.full)
+  )
 
 // Distribution
 

--- a/project/ProjectPlugin.scala
+++ b/project/ProjectPlugin.scala
@@ -1,4 +1,4 @@
-import de.heikoseeberger.sbtheader.HeaderPattern
+import de.heikoseeberger.sbtheader.License._
 import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
 import sbt.Keys._
 import sbt._
@@ -11,6 +11,21 @@ object ProjectPlugin extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
 
   override def requires: Plugins = plugins.JvmPlugin && OrgPoliciesPlugin
+
+  object autoImport {
+
+    lazy val V = new {
+      val scala212: String            = "2.12.10"
+      val cats: String                = "2.0.0"
+      val monocle: String             = "2.0.0"
+      val shapeless: String           = "2.3.3"
+      val scalatest: String           = "3.0.8"
+      val scalacheck: String          = "1.14.2"
+      val scalacheckShapeless: String = "1.2.3"
+    }
+  }
+
+  import autoImport._
 
   override def projectSettings: Seq[Def.Setting[_]] =
     Seq(
@@ -25,23 +40,17 @@ object ProjectPlugin extends AutoPlugin {
         organizationEmail = "hello@47deg.com"
       ),
       orgLicenseSetting := ApacheLicense,
-      scalaVersion := "2.11.11",
+      scalaVersion := V.scala212,
       scalaOrganization := "org.scala-lang",
-      crossScalaVersions := Seq("2.11.11"),
       resolvers ++= Seq(
         Resolver.mavenLocal,
         Resolver.sonatypeRepo("snapshots"),
         Resolver.sonatypeRepo("releases")
       ),
-      scalacOptions := sbtorgpolicies.model.scalacCommonOptions,
-      headers := Map(
-        "scala" -> (HeaderPattern.cStyleBlockComment,
-        s"""|/*
-            | * scala-exercises - ${name.value}
-            | * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
-            | */
-            |
-            |""".stripMargin)
-      )
+      scalacOptions := scalacCommonOptions ++ scalacLanguageOptions ++ Seq("-Ypartial-unification"),
+      headerLicense := Some(Custom(s"""| scala-exercises - ${name.value}
+                                       | Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+                                       |
+                                       |""".stripMargin))
     )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.13
+sbt.version = 1.2.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,6 @@
-resolvers ++= Seq(Resolver.sonatypeRepo("snapshots"))
-addSbtPlugin("org.scala-exercises" % "sbt-exercise" % "0.4.0-SNAPSHOT", "0.13", "2.10")
-addSbtPlugin("com.47deg"         % "sbt-org-policies" % "0.5.13")
+resolvers ++= Seq(
+  Resolver.sonatypeRepo("snapshots")
+)
+
+addSbtPlugin("org.scala-exercises" % "sbt-exercise"     % "0.5.0-SNAPSHOT")
+addSbtPlugin("com.47deg"           % "sbt-org-policies" % "0.12.0-M3")

--- a/src/main/scala/monocle/IsoExercises.scala
+++ b/src/main/scala/monocle/IsoExercises.scala
@@ -1,10 +1,12 @@
 /*
- * scala-exercises - exercises-monocle
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-monocle
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
-package monocle
+package monoclelib
 
+import monocle.Iso
 import monocle.macros.GenIso
 import org.scalatest._
 import org.scalaexercises.definitions._
@@ -32,7 +34,7 @@ object IsoHelper {
  *
  * An [[http://julien-truffaut.github.io/Monocle/optics/iso.html `Iso`]] is an optic which converts elements of type `S` into elements of type `A` without loss.
  *
- * Consider a case class Person with two fields:
+ * Consider a case class `Person` with two fields:
  *
  * {{{
  *   case class Person(name: String, age: Int)
@@ -96,7 +98,9 @@ object IsoExercises extends FlatSpec with Matchers with Section {
     stringToList.modify(_.tail)("Hello") should be(res0)
 
   /**
-   * We defined several macros to simplify the generation of Iso between a case class and its Tuple equivalent. All macros are defined in a separate module (see modules).
+   * = Iso Generation =
+   *
+   * We defined several macros to simplify the generation of `Iso` between a case class and its `Tuple` equivalent. All macros are defined in a separate module (see modules).
    * {{{
    *     case class MyString(s: String)
    *     case class Foo()

--- a/src/main/scala/monocle/MonocleLib.scala
+++ b/src/main/scala/monocle/MonocleLib.scala
@@ -1,11 +1,11 @@
 /*
- * scala-exercises - exercises-monocle
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-monocle
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
-package monocleex
+package monoclelib
 
-import monocle.{IsoExercises, OptionalExercises, PrismExercises, TraversalExercises}
 import org.scalaexercises.definitions._
 
 /** Monocle is an optics library for Scala (and Scala.js) strongly inspired by Haskell Lens.

--- a/src/main/scala/monocle/OptionalExercises.scala
+++ b/src/main/scala/monocle/OptionalExercises.scala
@@ -1,11 +1,12 @@
 /*
- * scala-exercises - exercises-monocle
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-monocle
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
-package monocle
+package monoclelib
 
-import monocle.law.OptionalLaws
+import monocle.Optional
 import org.scalaexercises.definitions._
 import org.scalatest._
 
@@ -77,10 +78,10 @@ object OptionalExercises extends FlatSpec with Matchers with Section {
    *
    * {{{
    *   head.getOrModify(xs)
-   *     // res2: scalaz.\/[List[Int],Int] = \/-(1)
+   *     // res2: Either[List[Int],Int] = Right(1)
    *
    *   head.getOrModify(ys)
-   *     // res3: scalaz.\/[List[Int],Int] = -\/(List())
+   *     // res3: Either[List[Int],Int] = Left(List())
    * }}}
    *
    * The function `getOrModify` is mostly used for polymorphic optics. If you use monomorphic optics, use function `getOption`

--- a/src/main/scala/monocle/PrismExercises.scala
+++ b/src/main/scala/monocle/PrismExercises.scala
@@ -1,10 +1,12 @@
 /*
- * scala-exercises - exercises-monocle
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-monocle
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
-package monocle
+package monoclelib
 
+import monocle.Prism
 import org.scalaexercises.definitions._
 import org.scalatest._
 
@@ -176,9 +178,9 @@ object PrismExercises extends FlatSpec with Matchers with Section {
    *
    * == Prism Laws ==
    *
-   * A `Prism` must satisfy all properties defined in `PrismLaws` from the core module. You can check the validity of your own `Prisms` using `PrismTests` from the law module.
+   * A `Prism` must satisfy all properties defined in `PrismLaws` from the core module. You can check the validity of your own `Prisms` using `PrismTests` from the `law` module.
    *
-   * In particular, a `Prism` must verify that `getOption` and `reverseGet` allow a full round trip if the Prism matches i.e. if `getOption` returns a `Some`.
+   * In particular, a Prism` must verify that `getOption` and `reverseGet` allow a full round trip if the Prism matches i.e. if `getOption` returns a `Some`.
    *
    *
    */

--- a/src/main/scala/monocle/TraversalExercises.scala
+++ b/src/main/scala/monocle/TraversalExercises.scala
@@ -1,28 +1,28 @@
 /*
- * scala-exercises - exercises-monocle
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-monocle
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
-package monocle
+package monoclelib
 
-import org.scalatest._
 import org.scalaexercises.definitions._
+import org.scalatest._
+import monocle.Traversal
 
 object TraversalHelper {
 
   val xs = List(1, 2, 3, 4, 5)
 
-  import scalaz.std.list._ // to get the Traverse instance for List
+  import cats.implicits._ // to get all cats instances including Traverse[List]
   val eachL = Traversal.fromTraverse[List, Int]
 
   case class Point(id: String, x: Int, y: Int)
 
   val points = Traversal.apply2[Point, Int](_.x, _.y)((x, y, p) => p.copy(x = x, y = y))
 
-  import scalaz.Applicative
-  import scalaz.std.map._
-  import scalaz.syntax.traverse._
-  import scalaz.syntax.applicative._
+  import cats.Applicative
+  import _root_.alleycats.std.map._
 
   def filterKey[K, V](predicate: K => Boolean): Traversal[Map[K, V], V] =
     new Traversal[Map[K, V], V] {
@@ -30,7 +30,7 @@ object TraversalHelper {
         s.map {
           case (k, v) =>
             k -> (if (predicate(k)) f(v) else v.pure[F])
-        }.sequenceU
+        }.sequence
     }
 
   val m = Map(1 -> "one", 2 -> "two", 3 -> "three", 4 -> "Four")
@@ -39,15 +39,15 @@ object TraversalHelper {
 
 /** == Traversal ==
  *
- * A [[http://julien-truffaut.github.io/Monocle/optics/traversal.html `Traversal`]]  is the generalisation of an `Optional` to several targets. In other word, a `Traversal` allows to focus from a type `S` into `0` to n values of type `A`.
+ * A [[http://julien-truffaut.github.io/Monocle/optics/traversal.html `Traversal`]]  is the generalisation of an `Optional` to several targets. In other word, a `Traversal` allows to focus from a type `S` into 0 to n values of type `A`.
  *
- * The most common example of a `Traversal` would be to focus into all elements inside of a container (e.g. `List`, `Vector`, `Option`). To do this we will use the relation between the typeclass `scalaz.Traverse` and `Traversal`:
+ * The most common example of a `Traversal` would be to focus into all elements inside of a container (e.g. `List`, `Vector`, `Option`). To do this we will use the relation between the typeclass `cats.Traverse` and `Traversal`:
  *
  * {{{
- *   import monocle.Traversal
- *   import scalaz.std.list._   // to get the Traverse instance for List
+ * import monocle.Traversal
+ * import cats.implicits._   // to get all cats instances including Traverse[List]
  *
- *   val xs = List(1,2,3,4,5)
+ * val xs = List(1,2,3,4,5)
  * }}}
  *
  * @param name traversal
@@ -100,21 +100,19 @@ object TraversalExercises extends FlatSpec with Matchers with Section {
    *
    * For example, let’s write a `Traversal` for `Map` that will focus into all values where the key satisfies a certain predicate:
    * {{{
-   *   import monocle.Traversal
-   *   import scalaz.Applicative
-   *   import scalaz.std.map._
-   *   import scalaz.syntax.traverse._
-   *   import scalaz.syntax.applicative._
+   * import monocle.Traversal
+   * import cats.Applicative
+   * import alleycats.std.map._ // to get Traverse instance for Map (SortedMap does not require this import)
    *
-   *   def filterKey[K, V](predicate: K => Boolean): Traversal[Map[K, V], V] =
+   * def filterKey[K, V](predicate: K => Boolean): Traversal[Map[K, V], V] =
    *     new Traversal[Map[K, V], V]{
    *       def modifyF[F[_]: Applicative](f: V => F[V])(s: Map[K, V]): F[Map[K, V]] =
-   *       s.map{ case (k, v) =>
-   *       k -> (if(predicate(k)) f(v) else v.pure[F])
-   *    }.sequenceU
-   *   }
+   *         s.map{ case (k, v) =>
+   *           k -> (if(predicate(k)) f(v) else v.pure[F])
+   *         }.sequence
+   *     }
    *
-   *   val m = Map(1 -> "one", 2 -> "two", 3 -> "three", 4 -> "Four")
+   * val m = Map(1 -> "one", 2 -> "two", 3 -> "three", 4 -> "Four")
    * }}}
    */
   def exerciseModifyF(res0: Map[Int, String]) = {

--- a/src/test/scala/monocle/IsoSpec.scala
+++ b/src/test/scala/monocle/IsoSpec.scala
@@ -1,15 +1,16 @@
 /*
- * scala-exercises - exercises-monocle
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-monocle
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
-package monocle
+package monoclelib
 
-import monocle.IsoHelper.Person
-import org.scalacheck.Shapeless._
+import IsoHelper.Person
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.FunSuite
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class IsoSpec extends FunSuite with Checkers {

--- a/src/test/scala/monocle/LensSpec.scala
+++ b/src/test/scala/monocle/LensSpec.scala
@@ -1,17 +1,17 @@
 /*
- * scala-exercises - exercises-monocle
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-monocle
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
-package monocle
+package monoclelib
 
-import monocleex.LensExercises
-import monocleex.LensHelper.{Address, Person}
+import LensHelper.{Address, Person, Point}
 import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.FunSuite
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class LensSpec extends FunSuite with Checkers {
@@ -69,6 +69,19 @@ class LensSpec extends FunSuite with Checkers {
     )
   }
 
+  test("exercise compose macro") {
+    check(
+      Test.testSuccess(
+        LensExercises.exerciseComposeMacro _,
+        Person("Mike", 21, LensHelper.address) :: HNil
+      )
+    )
+  }
+
+  test("exercise clens prism composition") {
+    check(Test.testSuccess(LensExercises.exerciseLensPrismComposition _, Option(1) :: HNil))
+  }
+
   test("exercise lens generation") {
     check(
       Test.testSuccess(
@@ -76,6 +89,14 @@ class LensSpec extends FunSuite with Checkers {
         Person("John", 20, Address(10, "Iffley Road")) :: HNil
       )
     )
+  }
+
+  test("exercise lens macro annotation") {
+    check(Test.testSuccess(LensExercises.exerciseLensMacroAnn _, 5 :: Point(5, 0) :: HNil))
+  }
+
+  test("exercise lens macro annotation prefix") {
+    check(Test.testSuccess(LensExercises.exerciseLensMacroAnnPrefix _, 5 :: HNil))
   }
 
   test("exercise laws") {

--- a/src/test/scala/monocle/OptionalSpec.scala
+++ b/src/test/scala/monocle/OptionalSpec.scala
@@ -1,17 +1,16 @@
 /*
- * scala-exercises - exercises-monocle
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-monocle
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
-package monocle
+package monoclelib
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.FunSuite
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
-
-import scalaz.{-\/, \/-}
 
 class OptionalSpec extends FunSuite with Checkers {
 

--- a/src/test/scala/monocle/PrismSpec.scala
+++ b/src/test/scala/monocle/PrismSpec.scala
@@ -1,16 +1,17 @@
 /*
- * scala-exercises - exercises-monocle
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-monocle
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
-package monocle
+package monoclelib
 
-import monocle.PrismHelper.{JNum, JStr, Json}
+import PrismHelper.{JNum, JStr}
 import org.scalaexercises.Test
 import org.scalatest.FunSuite
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 
-import org.scalacheck.Shapeless._
+import org.scalacheck.ScalacheckShapeless._
 import shapeless.HNil
 
 class PrismSpec extends FunSuite with Checkers {

--- a/src/test/scala/monocle/TraversalSpec.scala
+++ b/src/test/scala/monocle/TraversalSpec.scala
@@ -1,15 +1,16 @@
 /*
- * scala-exercises - exercises-monocle
- * Copyright (C) 2015-2016 47 Degrees, LLC. <http://www.47deg.com>
+ *  scala-exercises - exercises-monocle
+ *  Copyright (C) 2015-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
  */
 
-package monocle
+package monoclelib
 
-import monocle.TraversalHelper.Point
-import org.scalacheck.Shapeless._
+import TraversalHelper.Point
+import org.scalacheck.ScalacheckShapeless._
 import org.scalaexercises.Test
 import org.scalatest.FunSuite
-import org.scalatest.prop.Checkers
+import org.scalatestplus.scalacheck.Checkers
 import shapeless.HNil
 
 class TraversalSpec extends FunSuite with Checkers {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.2-SNAPSHOT"
+version in ThisBuild := "0.5.0-SNAPSHOT"


### PR DESCRIPTION
This PR updates the library to Scala 2.12.10 and makes it compatible with Scala Exercises 0.5.0-SNAPSHOT. Dependencies for the library and exercises are updated using the [Monocle documentation](http://julien-truffaut.github.io/Monocle/modules.html).